### PR TITLE
added function 14 to scan database names

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -32,6 +32,7 @@ function main {
   echo -e "11)${BGREEN} Flush Elementor cache${NC} - flushes WordPress Elementor cache."
   echo -e "12)${BGREEN} Flush LiteSpeed cache${NC} - flushes WordPress LiteSpeed cache."
   echo -e "13)${BGREEN} Test PHP mail${NC} - allows to test PHP mail easier."
+  echo -e "14)${BGREEN} Scan and print databases${NC} - allows to see which databases belong to all domain/subdomain in WP sites."
   echo -e "0)${BRED} Exit${NC} - exits the script."
 
   while true; do
@@ -50,6 +51,7 @@ function main {
       11) SELECT=func_elementors;;
       12) SELECT=func_litespeeds;;
       13) SELECT=func_php_mails;;
+      14) SELECT=func_scan_databases;;
       0) SELECT=exit;;
       *) echo -e "${BRED}Invalid selection, try again.${NC}"; continue
     esac
@@ -820,6 +822,42 @@ function func_php_mail_subdomain {
     cd ~/domains/"${domain_name}"/public_html/"${subdomainName}" && wget -c https://fix.lukasba.com/phpmail.txt -O mailtest.php && php -f mailtest.php
     rm mailtest.php
     echo -e "\e[0m"
+  return 1
+}
+
+function func_scan_databases() {
+  greenText() {
+    echo -e "The domain (\033[32m$1\033[0m) has this DB_NAME (\033[32m$2\033[0m)"
+  }
+
+  echo "Select an option:"
+  echo "1. Main domains"
+  echo "2. Subdomains"
+  read option
+
+  if [ "$option" == "1" ]; then
+    for domain in $(ls /home/"$USER"/domains); do
+      echo "Checking domain: $domain"
+      wp_config="/home/$USER/domains/$domain/public_html/wp-config.php"
+      if [ -f "$wp_config" ]; then
+        db_name=$(awk -F "'" '/DB_NAME/ {print $4}' "$wp_config")
+        greenText "$domain" "$db_name"
+      fi
+    done
+  elif [ "$option" == "2" ]; then
+    echo "Enter main domain name:"
+    read main_domain
+    for subdomain in $(find /home/"$USER"/domains/"$main_domain"/public_html -maxdepth 1 -type d | tail -n +2); do
+      wp_config="$subdomain/wp-config.php"
+      if [ -f "$wp_config" ]; then
+        db_name=$(awk -F "'" '/DB_NAME/ {print $4}' "$wp_config")
+        subdomain_name=$(echo "$subdomain" | awk -F/ '{print $NF}')
+        greenText "$subdomain_name.$main_domain" "$db_name"
+      fi
+    done
+  else
+    echo "Usage: check_db_names [1|2]"
+  fi
   return 1
 }
 


### PR DESCRIPTION
This function has the capability to scan the domains folder for all domains and print out the DB_NAME of each website if it's a WordPress application. It can also allow the user to submit a domain name to scan, then scan all folders inside the main domain to check if there is a subdomain folder with WordPress installed, and if yes, it'll print out all the databases for the subdomains as well. It can be used both from public_html and also from the domains/ tab on shared hosting plans on hPanel